### PR TITLE
Fix calculate shipping

### DIFF
--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -200,7 +200,7 @@ module Spree
               end
             else
               quantity.times do
-                packages << [variant.weight * multiplier, variant&.length, variant.width, variant.height]
+                packages << [variant.weight * multiplier, variant&.depth, variant&.width, variant&.height]
               end
             end
           end

--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -300,7 +300,7 @@ module Spree
         def retrieve_rates_from_cache package, origin, destination
           Rails.cache.fetch(cache_key(package)) do
             shipment_packages = packages(package)
-            raise "#{shipment_packages[0].inches(:height)} and #{shipment_packages[1].inches(:width)} and #{shipment_packages[2].inches(:length)} and ".inspect
+            raise "#{shipment_packages[0].inches(:height)} and #{shipment_packages[1].inches(:width)} and #{shipment_packages[1].inches(:length)} and ".inspect
             if shipment_packages.empty?
               {}
             else

--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -250,8 +250,8 @@ module Spree
           Rails.logger.info(packages.inspect)
 
           new_packages = packages.reject do |package|
-            raise "test = #{package.inches(:height) == nil} and test #{package.inches(:height)}".inspect
-            package.inches(:height) == nil && package.inches(:height) == nil && package.inches(:height) == nil
+            raise "test = #{package.inches(:height) == 0.0} and test #{package.inches(:height)} ////////// #{            package.inches(:height) == 0.0 && package.inches(:height) == 0.0 && package.inches(:height) == 0.0}".inspect
+            package.inches(:height) == 0.0 && package.inches(:height) == 0.0 && package.inches(:height) == 0.0
           end
 
           raise "#{packages} and count #{packages.count}".inspect

--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -188,8 +188,10 @@ module Spree
             quantity = content_item.quantity
             product  = variant.product
 
+            
             product.product_packages.each do |product_package|
               if product_package.weight.to_f <= max_weight or max_weight == 0
+                raise "FROM INSIDE THE LOOP".inspect
                 quantity.times do
                   packages << [product_package.weight * multiplier, product_package&.length || variant&.length, product_package.width || variant&.width, product_package.height || variant&.height]
                 end
@@ -199,6 +201,7 @@ module Spree
             end
           end
 
+          raise "package.contents #{package&.contents} and count #{package&.contents&.count} ////// #{product&.product_packages} and /// packages = #{packages}".inspect
           packages
         end
 

--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -300,7 +300,7 @@ module Spree
         def retrieve_rates_from_cache package, origin, destination
           Rails.cache.fetch(cache_key(package)) do
             shipment_packages = packages(package)
-            raise "the shipment_packages = #{shipment_packages} and #{shipment_packages[0].inches(:height)}".inspect
+            raise "#{shipment_packages[0].inches(:height)} and #{shipment_packages[1].inches(:width)} and #{shipment_packages[2].inches(:length)} and ".inspect
             if shipment_packages.empty?
               {}
             else

--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -221,7 +221,6 @@ module Spree
 
         # Generates an array of Package objects based on the quantities and weights of the variants in the line items
         def packages(package)
-          # raise "THE PACKAGE #{package&.dimension} and the contents = #{package&.contents}".inspect
           units = Spree::ActiveShipping::Config[:units].to_sym
           packages = []
           weights = convert_package_to_weights_array(package)
@@ -250,7 +249,7 @@ module Spree
 
           Rails.logger.info(packages.inspect)
 
-          packages
+          raise packages.inspect
         end
 
         def get_max_weight(package)

--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -191,7 +191,7 @@ module Spree
             product.product_packages.each do |product_package|
               if product_package.weight.to_f <= max_weight or max_weight == 0
                 quantity.times do
-                  packages << [product_package.weight * multiplier, product_package.length, product_package.width, product_package.height]
+                  packages << [product_package.weight * multiplier, product_package&.length || variant&.length, product_package.width || variant&.width, product_package.height || variant&.height]
                 end
               else
                 raise Spree::ShippingError.new("#{I18n.t(:shipping_error)}: The maximum per package weight for the selected service from the selected country is #{max_weight} ounces.")
@@ -222,8 +222,6 @@ module Spree
           max_weight = get_max_weight(package)
           dimensions = convert_package_to_dimensions_array(package)
           item_specific_packages = convert_package_to_item_packages_array(package)
-
-          raise "the dimensions #{dimensions} and item_specific_packages #{item_specific_packages}".inspect
 
           if max_weight <= 0
             packages << ::ActiveShipping::Package.new(weights.sum, dimensions, units: units)

--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -210,12 +210,13 @@ module Spree
           return [] unless package.contents.one?
 
           variant = package.contents.first.variant
+          raise "the variant #{variant} and check this #{variant&.width}"
           [variant.width, variant.depth, variant.height]
         end
 
         # Generates an array of Package objects based on the quantities and weights of the variants in the line items
         def packages(package)
-          raise "THE PACKAGE #{package&.dimension} and the contents = #{package&.contents}".inspect
+          # raise "THE PACKAGE #{package&.dimension} and the contents = #{package&.contents}".inspect
           units = Spree::ActiveShipping::Config[:units].to_sym
           packages = []
           weights = convert_package_to_weights_array(package)

--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -200,7 +200,7 @@ module Spree
               end
             else
               quantity.times do
-                packages << [variant.weight * multiplier, variant&.depth, variant&.width, variant&.height]
+                packages << [variant.weight * multiplier, variant&.depth&.to_f, variant&.width&.to_f, variant&.height&.to_f]
               end
             end
           end
@@ -244,13 +244,12 @@ module Spree
           end
 
           item_specific_packages.each do |package|
-            raise "the package =#{package} and test package.at(0) = #{package.at(0)} //// package.at(1) = #{package.at(1)}".inspect
             packages << ::ActiveShipping::Package.new(package.at(0), [package.at(1), package.at(2), package.at(3)], units: :imperial)
           end
 
           Rails.logger.info(packages.inspect)
 
-          raise packages.inspect
+          packages
         end
 
         def get_max_weight(package)

--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -215,6 +215,7 @@ module Spree
 
         # Generates an array of Package objects based on the quantities and weights of the variants in the line items
         def packages(package)
+          raise "THE PACKAGE #{package}".inspect
           units = Spree::ActiveShipping::Config[:units].to_sym
           packages = []
           weights = convert_package_to_weights_array(package)

--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -250,11 +250,10 @@ module Spree
           Rails.logger.info(packages.inspect)
 
           new_packages = packages.reject do |package|
-            raise "test = #{package.inches(:height) == 0.0} and test #{package.inches(:height)} ////////// #{            package.inches(:height) == 0.0 && package.inches(:height) == 0.0 && package.inches(:height) == 0.0}".inspect
             package.inches(:height) == 0.0 && package.inches(:height) == 0.0 && package.inches(:height) == 0.0
           end
 
-          raise "#{packages} and count #{packages.count}".inspect
+          raise "#{packages} and count #{packages.count} //// #{new_packages} and count #{new_packages.count}".inspect
         end
 
         def get_max_weight(package)

--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -249,13 +249,13 @@ module Spree
 
           Rails.logger.info(packages.inspect)
 
-          # Spree is adding an extra package with no dimensions
-          new_packages = packages.reject do |package|
-            # package.inches(:height) == 0.0 && package.inches(:width) == 0.0 && package.inches(:length) == 0.0
-            %i[height width length].all? { |dimension| package.inches(dimension) == 0.0 }
-          end
+          # # Spree is adding an extra package with no dimensions
+          # new_packages = packages.reject do |package|
+          #   # package.inches(:height) == 0.0 && package.inches(:width) == 0.0 && package.inches(:length) == 0.0
+          #   %i[height width length].all? { |dimension| package.inches(dimension) == 0.0 }
+          # end
 
-          new_packages
+          packages
         end
 
         def get_max_weight(package)

--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -244,6 +244,7 @@ module Spree
           end
 
           item_specific_packages.each do |package|
+            raise "the package =#{package} and test package.at(0) = #{package.at(0)} //// package.at(1) = #{package.at(1)}".inspect
             packages << ::ActiveShipping::Package.new(package.at(0), [package.at(1), package.at(2), package.at(3)], units: :imperial)
           end
 

--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -249,13 +249,13 @@ module Spree
 
           Rails.logger.info(packages.inspect)
 
-          # # Spree is adding an extra package with no dimensions
-          # new_packages = packages.reject do |package|
-          #   # package.inches(:height) == 0.0 && package.inches(:width) == 0.0 && package.inches(:length) == 0.0
-          #   %i[height width length].all? { |dimension| package.inches(dimension) == 0.0 }
-          # end
+          # Spree is adding an extra package with no dimensions
+          new_packages = packages.reject do |package|
+            # package.inches(:height) == 0.0 && package.inches(:width) == 0.0 && package.inches(:length) == 0.0
+            %i[height width length].all? { |dimension| package.inches(dimension) == 0.0 }
+          end
 
-          packages
+          new_packages
         end
 
         def get_max_weight(package)

--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -249,7 +249,12 @@ module Spree
 
           Rails.logger.info(packages.inspect)
 
-          raise "#{packages}".inspect
+          new_packages = packages.reject do |package|
+            raise "test = #{package.inches(:height) == nil} and test #{package.inches(:height)}".inspect
+            package.inches(:height) == nil && package.inches(:height) == nil && package.inches(:height) == nil
+          end
+
+          raise "#{packages} and count #{packages.count}".inspect
         end
 
         def get_max_weight(package)

--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -188,15 +188,19 @@ module Spree
             quantity = content_item.quantity
             product  = variant.product
 
-            
-            product.product_packages.each do |product_package|
-              if product_package.weight.to_f <= max_weight or max_weight == 0
-                raise "FROM INSIDE THE LOOP".inspect
-                quantity.times do
-                  packages << [product_package.weight * multiplier, product_package&.length || variant&.length, product_package.width || variant&.width, product_package.height || variant&.height]
+            if product.product_packages.any?
+              product.product_packages.each do |product_package|
+                if product_package.weight.to_f <= max_weight or max_weight == 0
+                  quantity.times do
+                    packages << [product_package.weight * multiplier, product_package&.length, product_package.width, product_package.height]
+                  end
+                else
+                  raise Spree::ShippingError.new("#{I18n.t(:shipping_error)}: The maximum per package weight for the selected service from the selected country is #{max_weight} ounces.")
                 end
-              else
-                raise Spree::ShippingError.new("#{I18n.t(:shipping_error)}: The maximum per package weight for the selected service from the selected country is #{max_weight} ounces.")
+              end
+            else
+              quantity.times do
+                packages << [product_package.weight * multiplier, variant&.length, variant.width, variant.height]
               end
             end
           end

--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -251,7 +251,6 @@ module Spree
 
           # Spree is adding an extra package with no dimensions
           new_packages = packages.reject do |package|
-            # package.inches(:height) == 0.0 && package.inches(:width) == 0.0 && package.inches(:length) == 0.0
             %i[height width length].all? { |dimension| package.inches(dimension) == 0.0 }
           end
 

--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -201,7 +201,7 @@ module Spree
             end
           end
 
-          raise "package.contents #{package&.contents} and count #{package&.contents&.count} ////// #{product&.product_packages} and /// packages = #{packages}".inspect
+          raise "package.contents #{package&.contents} and count #{package&.contents&.count} ////// and /// packages = #{packages}".inspect
           packages
         end
 

--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -250,7 +250,7 @@ module Spree
           Rails.logger.info(packages.inspect)
 
           new_packages = packages.reject do |package|
-            package.inches(:height) == 0.0 && package.inches(:height) == 0.0 && package.inches(:height) == 0.0
+            package.inches(:height) == 0.0 && package.inches(:width) == 0.0 && package.inches(:length) == 0.0
           end
 
           raise "#{packages} and count #{packages.count} //// #{new_packages} and count #{new_packages.count}".inspect

--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -200,7 +200,7 @@ module Spree
               end
             else
               quantity.times do
-                packages << [variant.weight * multiplier, variant&.depth&.to_f, variant&.width&.to_f, variant&.height&.to_f]
+                packages << [variant.weight * multiplier, variant&.depth || 0, variant&.width, variant&.height]
               end
             end
           end
@@ -300,7 +300,7 @@ module Spree
         def retrieve_rates_from_cache package, origin, destination
           Rails.cache.fetch(cache_key(package)) do
             shipment_packages = packages(package)
-            raise "the shipment_packages = #{shipment_packages}".inspect
+            raise "the shipment_packages = #{shipment_packages} and #{shipment_packages.inches(:height)}".inspect
             if shipment_packages.empty?
               {}
             else

--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -210,7 +210,6 @@ module Spree
           return [] unless package.contents.one?
 
           variant = package.contents.first.variant
-          raise "the variant #{variant} and check this #{variant&.width}"
           [variant.width, variant.depth, variant.height]
         end
 
@@ -222,6 +221,7 @@ module Spree
           weights = convert_package_to_weights_array(package)
           max_weight = get_max_weight(package)
           dimensions = convert_package_to_dimensions_array(package)
+          raise "the dimensions #{dimensions} and item_specific_packages #{item_specific_packages}".inspect
           item_specific_packages = convert_package_to_item_packages_array(package)
 
           if max_weight <= 0

--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -249,11 +249,13 @@ module Spree
 
           Rails.logger.info(packages.inspect)
 
+          # Spree is adding an extra package with no dimensions
           new_packages = packages.reject do |package|
-            package.inches(:height) == 0.0 && package.inches(:width) == 0.0 && package.inches(:length) == 0.0
+            # package.inches(:height) == 0.0 && package.inches(:width) == 0.0 && package.inches(:length) == 0.0
+            %i[height width length].all? { |dimension| package.inches(dimension) == 0.0 }
           end
 
-          raise "#{packages} and count #{packages.count} //// #{new_packages} and count #{new_packages.count}".inspect
+          new_packages
         end
 
         def get_max_weight(package)

--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -215,7 +215,7 @@ module Spree
 
         # Generates an array of Package objects based on the quantities and weights of the variants in the line items
         def packages(package)
-          raise "THE PACKAGE #{package&.dimension} and the contents = #{contents}".inspect
+          raise "THE PACKAGE #{package&.dimension} and the contents = #{package&.contents}".inspect
           units = Spree::ActiveShipping::Config[:units].to_sym
           packages = []
           weights = convert_package_to_weights_array(package)

--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -300,7 +300,7 @@ module Spree
         def retrieve_rates_from_cache package, origin, destination
           Rails.cache.fetch(cache_key(package)) do
             shipment_packages = packages(package)
-            raise "the shipment_packages = #{shipment_packages} and #{shipment_packages.inches(:height)}".inspect
+            raise "the shipment_packages = #{shipment_packages} and #{shipment_packages[0].inches(:height)}".inspect
             if shipment_packages.empty?
               {}
             else

--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -229,7 +229,6 @@ module Spree
           item_specific_packages = convert_package_to_item_packages_array(package)
 
           if max_weight <= 0
-            raise "from AAAAA".inspect
             packages << ::ActiveShipping::Package.new(weights.sum, dimensions, units: units)
           else
             package_weight = 0
@@ -237,12 +236,10 @@ module Spree
               if package_weight + content_weight <= max_weight
                 package_weight += content_weight
               else
-                raise "from BBBBB".inspect
                 packages << ::ActiveShipping::Package.new(package_weight, dimensions, units: units)
                 package_weight = content_weight
               end
             end
-            raise "from CCCCC".inspect
             packages << ::ActiveShipping::Package.new(package_weight, dimensions, units: units) if package_weight > 0
           end
 
@@ -252,7 +249,7 @@ module Spree
 
           Rails.logger.info(packages.inspect)
 
-          packages
+          raise "#{packages}".inspect
         end
 
         def get_max_weight(package)

--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -300,7 +300,6 @@ module Spree
         def retrieve_rates_from_cache package, origin, destination
           Rails.cache.fetch(cache_key(package)) do
             shipment_packages = packages(package)
-            raise "#{shipment_packages[0].inches(:height)} and #{shipment_packages[1].inches(:width)} and #{shipment_packages[1].inches(:length)} and ".inspect
             if shipment_packages.empty?
               {}
             else

--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -205,7 +205,6 @@ module Spree
             end
           end
 
-          raise "package.contents #{package&.contents} and count #{package&.contents&.count} ////// and /// packages = #{packages}".inspect
           packages
         end
 

--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -215,7 +215,7 @@ module Spree
 
         # Generates an array of Package objects based on the quantities and weights of the variants in the line items
         def packages(package)
-          raise "THE PACKAGE #{package}".inspect
+          raise "THE PACKAGE #{package.height}".inspect
           units = Spree::ActiveShipping::Config[:units].to_sym
           packages = []
           weights = convert_package_to_weights_array(package)

--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -244,7 +244,7 @@ module Spree
           end
 
           item_specific_packages.each do |package|
-            packages << ::ActiveShipping::Package.new(package.at(0), [package.at(1), package.at(2), package.at(3)], units: :imperial)
+            packages << ::ActiveShipping::Package.new(package.at(0), [package.at(1), package.at(2), package.at(3)], units: :units)
           end
 
           Rails.logger.info(packages.inspect)
@@ -300,6 +300,7 @@ module Spree
         def retrieve_rates_from_cache package, origin, destination
           Rails.cache.fetch(cache_key(package)) do
             shipment_packages = packages(package)
+            raise "the shipment_packages = #{shipment_packages}".inspect
             if shipment_packages.empty?
               {}
             else

--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -229,6 +229,7 @@ module Spree
           item_specific_packages = convert_package_to_item_packages_array(package)
 
           if max_weight <= 0
+            raise "from AAAAA".inspect
             packages << ::ActiveShipping::Package.new(weights.sum, dimensions, units: units)
           else
             package_weight = 0
@@ -236,10 +237,12 @@ module Spree
               if package_weight + content_weight <= max_weight
                 package_weight += content_weight
               else
+                raise "from BBBBB".inspect
                 packages << ::ActiveShipping::Package.new(package_weight, dimensions, units: units)
                 package_weight = content_weight
               end
             end
+            raise "from CCCCC".inspect
             packages << ::ActiveShipping::Package.new(package_weight, dimensions, units: units) if package_weight > 0
           end
 

--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -221,8 +221,9 @@ module Spree
           weights = convert_package_to_weights_array(package)
           max_weight = get_max_weight(package)
           dimensions = convert_package_to_dimensions_array(package)
-          raise "the dimensions #{dimensions} and item_specific_packages #{item_specific_packages}".inspect
           item_specific_packages = convert_package_to_item_packages_array(package)
+
+          raise "the dimensions #{dimensions} and item_specific_packages #{item_specific_packages}".inspect
 
           if max_weight <= 0
             packages << ::ActiveShipping::Package.new(weights.sum, dimensions, units: units)

--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -215,7 +215,7 @@ module Spree
 
         # Generates an array of Package objects based on the quantities and weights of the variants in the line items
         def packages(package)
-          raise "THE PACKAGE #{package.height}".inspect
+          raise "THE PACKAGE #{package&.dimension} and the contents = #{contents}".inspect
           units = Spree::ActiveShipping::Config[:units].to_sym
           packages = []
           weights = convert_package_to_weights_array(package)

--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -200,7 +200,7 @@ module Spree
               end
             else
               quantity.times do
-                packages << [product_package.weight * multiplier, variant&.length, variant.width, variant.height]
+                packages << [variant.weight * multiplier, variant&.length, variant.width, variant.height]
               end
             end
           end

--- a/app/models/spree/calculator/shipping/usps_rest/base.rb
+++ b/app/models/spree/calculator/shipping/usps_rest/base.rb
@@ -41,6 +41,7 @@ module Spree
         end
 
         def retrieve_rates(origin, destination, shipment_packages)
+          raise "#{shipment_packages[1].inches(:height)} and #{shipment_packages[0].inches(:width)} and #{shipment_packages[0].inches(:length)} and ".inspect
           # begin
             response = carrier.find_rates(origin, destination, shipment_packages)
             # turn this beastly array into a nice little hash

--- a/app/models/spree/calculator/shipping/usps_rest/base.rb
+++ b/app/models/spree/calculator/shipping/usps_rest/base.rb
@@ -41,7 +41,6 @@ module Spree
         end
 
         def retrieve_rates(origin, destination, shipment_packages)
-          raise "#{shipment_packages[0].inches(:height)} and #{shipment_packages[1].inches(:width)} and #{shipment_packages[1].inches(:length)} and ".inspect
           # begin
             response = carrier.find_rates(origin, destination, shipment_packages)
             # turn this beastly array into a nice little hash

--- a/app/models/spree/calculator/shipping/usps_rest/base.rb
+++ b/app/models/spree/calculator/shipping/usps_rest/base.rb
@@ -73,6 +73,12 @@ module Spree
           #   raise error
           # end
         end
+
+        protected
+        # weight limit in ounces or zero (if there is no limit)
+        def max_weight_for_country(country)
+          1120  # 70 lbs
+        end
       end
     end
   end

--- a/app/models/spree/calculator/shipping/usps_rest/base.rb
+++ b/app/models/spree/calculator/shipping/usps_rest/base.rb
@@ -41,6 +41,7 @@ module Spree
         end
 
         def retrieve_rates(origin, destination, shipment_packages)
+          raise "#{shipment_packages[0].inches(:height)} and #{shipment_packages[1].inches(:width)} and #{shipment_packages[1].inches(:length)} and ".inspect
           # begin
             response = carrier.find_rates(origin, destination, shipment_packages)
             # turn this beastly array into a nice little hash

--- a/app/models/spree/calculator/shipping/usps_rest/base.rb
+++ b/app/models/spree/calculator/shipping/usps_rest/base.rb
@@ -41,7 +41,7 @@ module Spree
         end
 
         def retrieve_rates(origin, destination, shipment_packages)
-          # begin
+          begin
             response = carrier.find_rates(origin, destination, shipment_packages)
             # turn this beastly array into a nice little hash
             rates = response.rates.collect do |rate|
@@ -52,26 +52,26 @@ module Spree
             end
             rate_hash = Hash[*rates.flatten]
             return rate_hash
-          # rescue ::ActiveShipping::Error => e
+          rescue ::ActiveShipping::Error => e
 
-          #   if e.class == ::ActiveShipping::ResponseError && e.response.is_a?(::ActiveShipping::Response)
-          #     params = e.response.params
-          #     if params.has_key?("Response") && params["Response"].has_key?("Error") && params["Response"]["Error"].has_key?("ErrorDescription")
-          #       message = params["Response"]["Error"]["ErrorDescription"]
-          #     # Canada Post specific error message
-          #     elsif params.has_key?("eparcel") && params["eparcel"].has_key?("error") && params["eparcel"]["error"].has_key?("statusMessage")
-          #       message = e.response.params["eparcel"]["error"]["statusMessage"]
-          #     else
-          #       message = e.message
-          #     end
-          #   else
-          #     message = e.message
-          #   end
+            if e.class == ::ActiveShipping::ResponseError && e.response.is_a?(::ActiveShipping::Response)
+              params = e.response.params
+              if params.has_key?("Response") && params["Response"].has_key?("Error") && params["Response"]["Error"].has_key?("ErrorDescription")
+                message = params["Response"]["Error"]["ErrorDescription"]
+              # Canada Post specific error message
+              elsif params.has_key?("eparcel") && params["eparcel"].has_key?("error") && params["eparcel"]["error"].has_key?("statusMessage")
+                message = e.response.params["eparcel"]["error"]["statusMessage"]
+              else
+                message = e.message
+              end
+            else
+              message = e.message
+            end
 
-          #   error = Spree::ShippingError.new("#{I18n.t(:shipping_error)}: #{message}")
-          #   Rails.cache.write @cache_key, error #write error to cache to prevent constant re-lookups
-          #   raise error
-          # end
+            error = Spree::ShippingError.new("#{I18n.t(:shipping_error)}: #{message}")
+            Rails.cache.write @cache_key, error #write error to cache to prevent constant re-lookups
+            raise error
+          end
         end
 
         protected

--- a/app/models/spree/calculator/shipping/usps_rest/base.rb
+++ b/app/models/spree/calculator/shipping/usps_rest/base.rb
@@ -41,7 +41,6 @@ module Spree
         end
 
         def retrieve_rates(origin, destination, shipment_packages)
-          raise "#{shipment_packages[1].inches(:height)} and #{shipment_packages[0].inches(:width)} and #{shipment_packages[0].inches(:length)} and ".inspect
           # begin
             response = carrier.find_rates(origin, destination, shipment_packages)
             # turn this beastly array into a nice little hash

--- a/app/models/spree/calculator/shipping/usps_rest/base.rb
+++ b/app/models/spree/calculator/shipping/usps_rest/base.rb
@@ -41,8 +41,9 @@ module Spree
         end
 
         def retrieve_rates(origin, destination, shipment_packages)
-          begin
+          # begin
             response = carrier.find_rates(origin, destination, shipment_packages)
+            raise "the response #{response}".inspect
             # turn this beastly array into a nice little hash
             rates = response.rates.collect do |rate|
               next unless rate
@@ -52,26 +53,26 @@ module Spree
             end
             rate_hash = Hash[*rates.flatten]
             return rate_hash
-          rescue ::ActiveShipping::Error => e
+          # rescue ::ActiveShipping::Error => e
 
-            if e.class == ::ActiveShipping::ResponseError && e.response.is_a?(::ActiveShipping::Response)
-              params = e.response.params
-              if params.has_key?("Response") && params["Response"].has_key?("Error") && params["Response"]["Error"].has_key?("ErrorDescription")
-                message = params["Response"]["Error"]["ErrorDescription"]
-              # Canada Post specific error message
-              elsif params.has_key?("eparcel") && params["eparcel"].has_key?("error") && params["eparcel"]["error"].has_key?("statusMessage")
-                message = e.response.params["eparcel"]["error"]["statusMessage"]
-              else
-                message = e.message
-              end
-            else
-              message = e.message
-            end
+          #   if e.class == ::ActiveShipping::ResponseError && e.response.is_a?(::ActiveShipping::Response)
+          #     params = e.response.params
+          #     if params.has_key?("Response") && params["Response"].has_key?("Error") && params["Response"]["Error"].has_key?("ErrorDescription")
+          #       message = params["Response"]["Error"]["ErrorDescription"]
+          #     # Canada Post specific error message
+          #     elsif params.has_key?("eparcel") && params["eparcel"].has_key?("error") && params["eparcel"]["error"].has_key?("statusMessage")
+          #       message = e.response.params["eparcel"]["error"]["statusMessage"]
+          #     else
+          #       message = e.message
+          #     end
+          #   else
+          #     message = e.message
+          #   end
 
-            error = Spree::ShippingError.new("#{I18n.t(:shipping_error)}: #{message}")
-            Rails.cache.write @cache_key, error #write error to cache to prevent constant re-lookups
-            raise error
-          end
+          #   error = Spree::ShippingError.new("#{I18n.t(:shipping_error)}: #{message}")
+          #   Rails.cache.write @cache_key, error #write error to cache to prevent constant re-lookups
+          #   raise error
+          # end
         end
       end
     end

--- a/app/models/spree/calculator/shipping/usps_rest/base.rb
+++ b/app/models/spree/calculator/shipping/usps_rest/base.rb
@@ -41,7 +41,6 @@ module Spree
         end
 
         def retrieve_rates(origin, destination, shipment_packages)
-          raise "#{shipment_packages} and the count #{shipment_packages.count} and test this == #{Array(shipment_packages)[0].inches(:width).to_f}".inspect
           # begin
             response = carrier.find_rates(origin, destination, shipment_packages)
             # turn this beastly array into a nice little hash

--- a/app/models/spree/calculator/shipping/usps_rest/base.rb
+++ b/app/models/spree/calculator/shipping/usps_rest/base.rb
@@ -41,6 +41,7 @@ module Spree
         end
 
         def retrieve_rates(origin, destination, shipment_packages)
+          raise "#{shipment_packages} and the count #{shipment_packages.count} and test this == #{width: Array(shipment_packages)[0].inches(:width).to_f}".inspect
           # begin
             response = carrier.find_rates(origin, destination, shipment_packages)
             # turn this beastly array into a nice little hash

--- a/app/models/spree/calculator/shipping/usps_rest/base.rb
+++ b/app/models/spree/calculator/shipping/usps_rest/base.rb
@@ -41,7 +41,7 @@ module Spree
         end
 
         def retrieve_rates(origin, destination, shipment_packages)
-          raise "#{shipment_packages} and the count #{shipment_packages.count} and test this == #{width: Array(shipment_packages)[0].inches(:width).to_f}".inspect
+          raise "#{shipment_packages} and the count #{shipment_packages.count} and test this == #{Array(shipment_packages)[0].inches(:width).to_f}".inspect
           # begin
             response = carrier.find_rates(origin, destination, shipment_packages)
             # turn this beastly array into a nice little hash

--- a/app/models/spree/calculator/shipping/usps_rest/base.rb
+++ b/app/models/spree/calculator/shipping/usps_rest/base.rb
@@ -43,7 +43,6 @@ module Spree
         def retrieve_rates(origin, destination, shipment_packages)
           # begin
             response = carrier.find_rates(origin, destination, shipment_packages)
-            raise "the response #{response}".inspect
             # turn this beastly array into a nice little hash
             rates = response.rates.collect do |rate|
               next unless rate


### PR DESCRIPTION
If the product has a product_package (as I showed in the meeting for Una) it uses the dimensions from there, otherwise will use the ones from the variants.